### PR TITLE
Update About section with new copy and tools grid

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -490,6 +490,61 @@ nav.navbar::after {
     box-shadow: 0 5px 0 var(--royal-purple);
 }
 
+/* Tools Grid */
+.tools-grid {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 1rem;
+    margin-top: 1rem;
+}
+
+.tool-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 1.25rem 0.75rem;
+    background: rgba(255, 255, 255, 0.03);
+    border: 2px solid rgba(255, 255, 255, 0.1);
+    border-radius: var(--border-radius-md);
+    transition: var(--transition-smooth);
+    cursor: default;
+}
+
+.tool-item i {
+    font-size: 2rem;
+    background: var(--gradient-90s);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    transition: var(--transition-smooth);
+}
+
+.tool-item span {
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    color: rgba(255, 255, 255, 0.6);
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    text-align: center;
+}
+
+.tool-item:hover {
+    border-color: var(--electric-blue);
+    background: rgba(0, 255, 255, 0.1);
+    transform: translateY(-5px);
+    box-shadow: 0 0 20px rgba(0, 255, 255, 0.3);
+}
+
+.tool-item:hover i {
+    transform: scale(1.2);
+}
+
+.tool-item:hover span {
+    color: var(--electric-blue);
+}
+
 /* ===========================================
    WHAT I DO / SERVICES SECTION
    =========================================== */
@@ -1213,6 +1268,19 @@ footer h3 .accent {
         text-align: center;
     }
 
+    .tools-grid {
+        grid-template-columns: repeat(5, 1fr);
+        gap: 0.75rem;
+    }
+
+    .tool-item {
+        padding: 1rem 0.5rem;
+    }
+
+    .tool-item i {
+        font-size: 1.75rem;
+    }
+
     .services-grid {
         grid-template-columns: 1fr;
         gap: 1.5rem;
@@ -1322,6 +1390,23 @@ footer h3 .accent {
     .skill-items {
         font-size: 0.75rem;
         padding: 0.4rem 1rem;
+    }
+
+    .tools-grid {
+        grid-template-columns: repeat(3, 1fr);
+        gap: 0.5rem;
+    }
+
+    .tool-item {
+        padding: 0.75rem 0.5rem;
+    }
+
+    .tool-item i {
+        font-size: 1.5rem;
+    }
+
+    .tool-item span {
+        font-size: 0.6rem;
     }
 
     .project-description {

--- a/index.html
+++ b/index.html
@@ -86,26 +86,62 @@
   <section id="about-me" class="fade-in-section">
     <div class="about-container">
       <div class="about-image">
-        <img src="./assets/images/portrait.JPG" alt="Professional headshot of Bryce Drawe, Full Stack Developer" id="portrait" loading="lazy" />
+        <img src="./assets/images/portrait.JPG" alt="Professional headshot of Bryce Drawe" id="portrait" loading="lazy" />
       </div>
       <div class="about-body">
-        <h3 class="section-title">About Me<span class="accent">.</span></h3>
+        <h3 class="section-title">About<span class="accent">.</span></h3>
         <p>
-          I am a Full Stack Developer that found a passion for the web through web marketing and now transitioned to building clean and intuitive applications using design and logic. I have received a certificate in Full Stack Web Development from the University of Utah. I use Javascript and other front-end technologies to build dynamic web experiences and elegant designs. I have applied my skills in design and user experience. I am a team player whose goal is to deliver a polished interface with a simple but powerful codebase. I use my marketing background to implement SEO traffic, and my technical knowledge in building user-friendly web applications.
+          I sit at the intersection of engineering, SEO, and conversion optimization.
         </p>
-        <h4>Skills</h4>
-        <ul class="skills">
-          <li class="skill-items">HTML</li>
-          <li class="skill-items">CSS</li>
-          <li class="skill-items">JavaScript</li>
-          <li class="skill-items">Express.js</li>
-          <li class="skill-items">Node.js</li>
-          <li class="skill-items">Jest.js</li>
-          <li class="skill-items">React.js</li>
-          <li class="skill-items">MongoDB</li>
-          <li class="skill-items">SQL</li>
-          <li class="skill-items">MySQL</li>
-        </ul>
+        <p>
+          Most "SEO experts" can't write code. Most developers don't understand search or conversion strategy. I do both — which means I can diagnose why your site underperforms AND fix it myself.
+        </p>
+        <p>
+          My background: I started in web marketing, got obsessed with why some sites convert and others don't, then went deep on the technical side. Now I run a consultancy where I help companies optimize performance, fix technical SEO issues, and run data-driven A/B tests.
+        </p>
+        <h4>Tools I Reach For</h4>
+        <div class="tools-grid">
+          <div class="tool-item">
+            <i class="devicon-javascript-plain"></i>
+            <span>JavaScript</span>
+          </div>
+          <div class="tool-item">
+            <i class="devicon-wordpress-plain"></i>
+            <span>WordPress</span>
+          </div>
+          <div class="tool-item">
+            <i class="devicon-gatsby-plain"></i>
+            <span>Gatsby</span>
+          </div>
+          <div class="tool-item">
+            <i class="devicon-google-plain"></i>
+            <span>Analytics</span>
+          </div>
+          <div class="tool-item">
+            <i class="fas fa-chart-bar"></i>
+            <span>Semrush</span>
+          </div>
+          <div class="tool-item">
+            <i class="fas fa-tachometer-alt"></i>
+            <span>GTmetrix</span>
+          </div>
+          <div class="tool-item">
+            <i class="fab fa-webflow"></i>
+            <span>Webflow</span>
+          </div>
+          <div class="tool-item">
+            <i class="fas fa-fire"></i>
+            <span>Hotjar</span>
+          </div>
+          <div class="tool-item">
+            <i class="fas fa-flask"></i>
+            <span>VWO</span>
+          </div>
+          <div class="tool-item">
+            <i class="fas fa-cube"></i>
+            <span>Storyblok</span>
+          </div>
+        </div>
       </div>
     </div>
   </section>


### PR DESCRIPTION
- Rewrite About copy to focus on SEO/engineering intersection
- Replace skills list with visual tools grid
- Add tool icons: JavaScript, WordPress, Gatsby, Analytics, Semrush, GTmetrix, Webflow, Hotjar, VWO, Storyblok
- Style tools grid with gradient icons and hover effects
- Add responsive layouts (5-col > 3-col on mobile)

https://claude.ai/code/session_01Urtvqkb3Q2r5jjkttbPn7m